### PR TITLE
Backport from parent repo - Allow upgrade of HTTParty and Nokogiri

### DIFF
--- a/fedex.gemspec
+++ b/fedex.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency 'httparty',            '~> 0.12.0'
-  s.add_dependency 'nokogiri',            '~> 1.6.0'
+  s.add_dependency 'httparty',            '>= 0.14.0'
+  s.add_dependency 'nokogiri',            '>= 1.5.6'
 
   s.add_development_dependency "rspec",   '~> 2.9.0'
   s.add_development_dependency 'vcr',     '~> 2.0.0'

--- a/lib/fedex/request/base.rb
+++ b/lib/fedex/request/base.rb
@@ -313,7 +313,7 @@ module Fedex
 
       # Parse response, convert keys to underscore symbols
       def parse_response(response)
-        response = sanitize_response_keys(response)
+        response = sanitize_response_keys(response.parsed_response)
       end
 
       # Recursively sanitizes the response object by cleaning up any hash keys.


### PR DESCRIPTION
Cherry-Pick of https://github.com/jazminschroeder/fedex/pull/129

Needed to bump Ruby and silence warnings:
```
/Users/flo/.rvm/gems/ruby-2.3.7@tu3/gems/json-1.8.6/lib/json/common.rb:155: warning: HTTParty::Response#respond_to?(:to_str) is old fashion which takes only one parameter
/Users/flo/.rvm/gems/ruby-2.3.7@tu3/gems/httparty-0.12.0/lib/httparty/response.rb:53: warning: respond_to? is defined here
```

This will be tested on staging before being merged.