### PR TITLE
Relax dependencies: Httparty, Nokogiri

### DIFF
--- a/fedex.gemspec
+++ b/fedex.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency 'httparty',            '~> 0.12.0'
-  s.add_dependency 'nokogiri',            '~> 1.6.0'
+  s.add_dependency 'httparty',            '>= 0.12.0'
+  s.add_dependency 'nokogiri',            '>= 1.6.0'
 
   s.add_development_dependency "rspec",   '~> 2.9.0'
   s.add_development_dependency 'vcr',     '~> 2.0.0'
@@ -28,6 +28,4 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-
-
 end

--- a/fedex.gemspec
+++ b/fedex.gemspec
@@ -16,13 +16,14 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency 'httparty',            '>= 0.12.0', '< 18.0'
-  s.add_dependency 'nokogiri',            '>= 1.6.0', '< 2.0'
+  s.add_dependency 'httparty', '>= 0.12.0', '< 0.18'
+  s.add_dependency 'nokogiri', '>= 1.6.0', '< 2.0'
 
-  s.add_development_dependency "rspec",   '~> 2.9.0'
-  s.add_development_dependency 'vcr',     '>= 5.0.0'
-  s.add_development_dependency 'webmock', '~> 1.8.0'
-  # s.add_runtime_dependency "rest-client"
+  s.add_development_dependency 'rspec', '~> 3.8.0'
+  s.add_development_dependency 'vcr', '~> 5.0.0'
+  s.add_development_dependency 'webmock', '~> 3.6.2'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'pry'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/fedex.gemspec
+++ b/fedex.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency 'httparty',            '>= 0.12.0'
-  s.add_dependency 'nokogiri',            '>= 1.6.0'
+  s.add_dependency 'httparty',            '>= 0.12.0', '< 18.0'
+  s.add_dependency 'nokogiri',            '>= 1.6.0', '< 2.0'
 
   s.add_development_dependency "rspec",   '~> 2.9.0'
-  s.add_development_dependency 'vcr',     '~> 2.0.0'
+  s.add_development_dependency 'vcr',     '>= 5.0.0'
   s.add_development_dependency 'webmock', '~> 1.8.0'
   # s.add_runtime_dependency "rest-client"
 

--- a/lib/fedex/request/base.rb
+++ b/lib/fedex/request/base.rb
@@ -313,12 +313,12 @@ module Fedex
 
       # Parse response, convert keys to underscore symbols
       def parse_response(response)
-        response = sanitize_response_keys(response)
+        sanitize_response_keys(response)
       end
 
       # Recursively sanitizes the response object by cleaning up any hash keys.
       def sanitize_response_keys(response)
-        if response.is_a?(Hash)
+        if response.is_a?(Hash) || response.is_a?(HTTParty::Response)
           response.inject({}) { |result, (key, value)| result[underscorize(key).to_sym] = sanitize_response_keys(value); result }
         elsif response.is_a?(Array)
           response.collect { |result| sanitize_response_keys(result) }

--- a/lib/fedex/version.rb
+++ b/lib/fedex/version.rb
@@ -1,3 +1,3 @@
 module Fedex
-  VERSION = "3.6.0"
+  VERSION = "3.6.1"
 end

--- a/spec/lib/fedex/address_spec.rb
+++ b/spec/lib/fedex/address_spec.rb
@@ -26,9 +26,9 @@ module Fedex
         it "validates the address" do
           address = fedex.validate_address(options)
 
-          address.residential.should be_true
-          address.business.should    be_false
-          address.score.should ==    100
+          address.residential.should == true
+          address.business.should == false
+          address.score.should == 100
 
           address.postal_code.should == "06850-3901"
         end

--- a/spec/lib/fedex/track_spec.rb
+++ b/spec/lib/fedex/track_spec.rb
@@ -30,7 +30,7 @@ module Fedex
 
         fail_options[:package_type] = "UNKNOWN_PACKAGE"
 
-        lambda { fedex.track(options) }.should raise_error
+        lambda { fedex.track(options) }.should raise_error(RuntimeError, "Unknown package type 'UNKNOWN_PACKAGE'")
       end
 
       it "allows short hand tracking number queries" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,9 @@ require 'rspec'
 require 'fedex'
 require 'support/vcr'
 require 'support/credentials'
+require 'pry'
 
 RSpec.configure do |c|
   c.filter_run_excluding :production unless fedex_production_credentials
+  c.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,4 +6,3 @@ require 'support/credentials'
 RSpec.configure do |c|
   c.filter_run_excluding :production unless fedex_production_credentials
 end
-

--- a/spec/support/credentials.rb
+++ b/spec/support/credentials.rb
@@ -10,6 +10,6 @@ private
 
 def credentials
   @credentials ||= begin
-    YAML.load_file("#{File.dirname(__FILE__)}/../config/fedex_credentials.yml")
+    YAML.load_file("#{File.dirname(__dir__)}/config/fedex_credentials.yml")
   end
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,13 +1,12 @@
 require 'vcr'
 
 VCR.configure do |c|
-  c.cassette_library_dir  = File.expand_path('../../vcr', __FILE__)
+  c.cassette_library_dir = 'spec/vcr'
   c.hook_into :webmock
 end
 
 RSpec.configure do |c|
   c.include Fedex::Helpers
-  c.treat_symbols_as_metadata_keys_with_true_values = true
   c.around(:each, :vcr) do |example|
     name = underscorize(example.metadata[:full_description].split(/\s+/, 2).join("/")).gsub(/[^\w\/]+/, "_")
     VCR.use_cassette(name) { example.call }


### PR DESCRIPTION
👍 @florrain 

Do not lock dependencies on older versions of Httparty and Nokogiri.

One found difference:

```ruby
# Httparty prior version 0.14 
response.is_a?(Hash) #=> true

# Httparty version >= 0.14 
response.is_a?(Hash) #=> false
```

So added one more check to `sanitize_response_keys`.
